### PR TITLE
Remove empty newlines at startup

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,8 +5,6 @@ globalVariables(c("."))
 ## Messages to be displayed when the user loads psychmeta:
 .onAttach <- function(libname, pkgname) {
     version <- read.dcf(file=system.file("DESCRIPTION", package=pkgname), fields="Version")
-    packageStartupMessage("\n")
-    packageStartupMessage("\n")
     packageStartupMessage("This is ", paste(pkgname, version))
     packageStartupMessage("Please report any bugs to improve functionality. \n")
 }


### PR DESCRIPTION
They create a pretty big unsightly white space on loading (in RStudio, it shows up as 4 blank lines for me). Other packages don't often seem to include any white space like this (e.g., https://github.com/OpenMx/OpenMx/blob/master/R/zzz.R)